### PR TITLE
Continue reading if the data read from the network is insufficient

### DIFF
--- a/bms.py
+++ b/bms.py
@@ -140,7 +140,9 @@ def bms_get_data(comms):
         if connection_type == "Serial":
             inc_data = comms.readline()
         else:
-            temp = comms.recv(4096)
+            temp = bytes()
+            while len(temp) == 0 or temp[-1] != 13:
+                temp = temp + comms.recv(4096)
             temp2 = temp.split(b'\r')
             # Decide which one to take:
             for element in range(0,len(temp2)):


### PR DESCRIPTION
This updates the read logic on the network path to read until all the required data is available.

Technically, it reads until the last character in the buffer is 0x13, which is not exactly the same
thing, as it is possible that a data packet might include a 0x013 in it, even though that is also
the framing character. I don't think it is intended as a delimiter, just a way of validating that the
entire packet is sane, but it is an expedient solution.

The correct solution would be to parse the stated length of the packet from the bytes received
and make sure to read that much data. This applies to both the network and serial interfaces,
so it is surprising that this has not arisen before this.